### PR TITLE
Make CertCache get certs url from discovery document

### DIFF
--- a/lib/certCache.js
+++ b/lib/certCache.js
@@ -2,9 +2,10 @@
 
 var request = require('request');
 
-var GOOGLE_OAUTH2_FEDERATED_SIGNON_CERTS_URL_ = 'https://www.googleapis.com/oauth2/v1/certs';
+var GOOGLE_DISCOVERY_DOCUMENT_URL = 'https://accounts.google.com/.well-known/openid-configuration';
 
 function CertCache() {
+  this.googleOAuth2FederatedSignonCertsUrl = null;
   this.certificateExpiry = null;
   this.certificateCache = null;
 }
@@ -17,8 +18,13 @@ CertCache.prototype.getFederatedGoogleCerts = function (callback) {
     return;
   }
 
+  if (!_this.googleOAuth2FederatedSignonCertsUrl){
+    _this.getGoogleCertsURI(callback);
+    return;
+  }
+
   var options = {
-    uri: GOOGLE_OAUTH2_FEDERATED_SIGNON_CERTS_URL_,
+    uri: _this.googleOAuth2FederatedSignonCertsUrl,
     json: true
   };
 
@@ -45,6 +51,24 @@ CertCache.prototype.getFederatedGoogleCerts = function (callback) {
     _this.certificateCache = body;
     callback(null, body, response);
   });
+};
+
+CertCache.prototype.getGoogleCertsURI = function (callback) {
+  var _this = this;
+  var options = {
+    uri: GOOGLE_DISCOVERY_DOCUMENT_URL,
+    json: true
+  };
+
+  request.get(options, function (err, response, body) {
+    if (err) {
+      callback('Failed to retrieve discovery document: ' + err, null, response);
+      return;
+    }
+    _this.googleOAuth2FederatedSignonCertsUrl = body.jwks_uri;
+    _this.getFederatedGoogleCerts(callback);
+  });
+
 };
 
 CertCache.global = new CertCache();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-id-token-verifier",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "A small library to validate a google ID token for consuming it in node.js backend server.",
   "main": "./lib/main.js",
   "scripts": {

--- a/test/cacheTest.js
+++ b/test/cacheTest.js
@@ -5,6 +5,7 @@ var assert = require('assert');
 var sinon = require('sinon');
 var request = require('request');
 var certCache = require('../lib/certCache');
+var openid_configuration = require('./fixtures/openid-configuration');
 var testOAuthCerts = require('./fixtures/oauthcerts');
 
 describe('certCache', function () {
@@ -14,7 +15,7 @@ describe('certCache', function () {
     stub
       .onFirstCall().yields(new Error('timeout'), { statusCode: 404, headers: {} }, null);
     stub
-      .onSecondCall().yields(null, { statusCode: 200, headers: {} }, testOAuthCerts);
+      .onSecondCall().yields(null, { statusCode: 200, headers: {} }, openid_configuration);
     stub
       .yields(null, { statusCode: 200, headers: {
         'cache-control': 'public, max-age=' + cacheAge + ', must-revalidate, no-transform'
@@ -34,7 +35,7 @@ describe('certCache', function () {
       assert.equal(_.isEmpty(keys), true);
       certCache.global.getFederatedGoogleCerts(function (err, keys) {
         assert.equal(_.isEmpty(err), true);
-        assert.equal(request.get.callCount, 2);
+        assert.equal(request.get.callCount, 3);
         assert.equal(_.isEmpty(keys), false);
         certCache.global.getFederatedGoogleCerts(function (err, keys) {
           assert.equal(_.isEmpty(err), true);

--- a/test/cacheTest.js
+++ b/test/cacheTest.js
@@ -17,6 +17,8 @@ describe('certCache', function () {
     stub
       .onSecondCall().yields(null, { statusCode: 200, headers: {} }, openid_configuration);
     stub
+      .onThirdCall().yields(new Error('timeout'), { statusCode: 404, headers: {} }, null);
+    stub
       .yields(null, { statusCode: 200, headers: {
         'cache-control': 'public, max-age=' + cacheAge + ', must-revalidate, no-transform'
         } }, testOAuthCerts);
@@ -34,16 +36,16 @@ describe('certCache', function () {
       assert.equal(request.get.callCount, 1);
       assert.equal(_.isEmpty(keys), true);
       certCache.global.getFederatedGoogleCerts(function (err, keys) {
-        assert.equal(_.isEmpty(err), true);
+        assert.equal(_.isEmpty(err), false);
         assert.equal(request.get.callCount, 3);
-        assert.equal(_.isEmpty(keys), false);
+        assert.equal(_.isEmpty(keys), true);
         certCache.global.getFederatedGoogleCerts(function (err, keys) {
           assert.equal(_.isEmpty(err), true);
-          assert.equal(request.get.callCount, 3);
+          assert.equal(request.get.callCount, 4);
           assert.equal(_.isEmpty(keys), false);
           certCache.global.getFederatedGoogleCerts(function (err, keys) {
             assert.equal(_.isEmpty(err), true);
-            assert.equal(request.get.callCount, 3);
+            assert.equal(request.get.callCount, 4);
             assert.equal(_.isEmpty(keys), false);
             done();
           });

--- a/test/fixtures/openid-configuration.json
+++ b/test/fixtures/openid-configuration.json
@@ -1,0 +1,51 @@
+{
+ "issuer": "https://accounts.google.com",
+ "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+ "token_endpoint": "https://www.googleapis.com/oauth2/v4/token",
+ "userinfo_endpoint": "https://www.googleapis.com/oauth2/v3/userinfo",
+ "revocation_endpoint": "https://accounts.google.com/o/oauth2/revoke",
+ "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
+ "response_types_supported": [
+  "code",
+  "token",
+  "id_token",
+  "code token",
+  "code id_token",
+  "token id_token",
+  "code token id_token",
+  "none"
+ ],
+ "subject_types_supported": [
+  "public"
+ ],
+ "id_token_signing_alg_values_supported": [
+  "RS256"
+ ],
+ "scopes_supported": [
+  "openid",
+  "email",
+  "profile"
+ ],
+ "token_endpoint_auth_methods_supported": [
+  "client_secret_post",
+  "client_secret_basic"
+ ],
+ "claims_supported": [
+  "aud",
+  "email",
+  "email_verified",
+  "exp",
+  "family_name",
+  "given_name",
+  "iat",
+  "iss",
+  "locale",
+  "name",
+  "picture",
+  "sub"
+ ],
+ "code_challenge_methods_supported": [
+  "plain",
+  "S256"
+ ]
+}


### PR DESCRIPTION
This commit makes the certCache load the certificate url from the discovery document, instead of having one hard-coded. This is in line with the recommendations here: https://developers.google.com/identity/protocols/OpenIDConnect#validatinganidtoken
