### PR TITLE
Move callback outside of try/catch

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -69,8 +69,9 @@ function verifyPayload(payload, audience) {
 
 exports.verify = function (idToken, audience, callback) {
   certCache.global.getFederatedGoogleCerts(function (err, keys) {
+    var decodedJWT = null;
     try {
-      var decodedJWT = decodeJWT(idToken);
+      decodedJWT = decodeJWT(idToken);
       verifySignature(decodedJWT, keys.keys);
       verifyPayload(decodedJWT.payload, audience);
     } catch (e) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -73,10 +73,9 @@ exports.verify = function (idToken, audience, callback) {
       var decodedJWT = decodeJWT(idToken);
       verifySignature(decodedJWT, keys.keys);
       verifyPayload(decodedJWT.payload, audience);
-
-      callback(null, decodedJWT.payload);
     } catch (e) {
       callback(e, null);
     }
+    callback(null, decodedJWT.payload);
   });
 };


### PR DESCRIPTION
Prevents weirds behaviour around swallowing of errors from the actual callback.
