### PR TITLE
Move callback outside of try/catch

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -70,13 +70,15 @@ function verifyPayload(payload, audience) {
 exports.verify = function (idToken, audience, callback) {
   certCache.global.getFederatedGoogleCerts(function (err, keys) {
     var decodedJWT = null;
+    var error = null;
     try {
       decodedJWT = decodeJWT(idToken);
       verifySignature(decodedJWT, keys.keys);
       verifyPayload(decodedJWT.payload, audience);
     } catch (e) {
-      callback(e, null);
+      error=e;
     }
+    if(error) return callback(error);
     callback(null, decodedJWT.payload);
   });
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -78,7 +78,9 @@ exports.verify = function (idToken, audience, callback) {
     } catch (e) {
       error=e;
     }
-    if(error) return callback(error);
+    if (error) { 
+      return callback(error);
+    }
     callback(null, decodedJWT.payload);
   });
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -69,8 +69,9 @@ function verifyPayload(payload, audience) {
 
 exports.verify = function (idToken, audience, callback) {
   certCache.global.getFederatedGoogleCerts(function (err, keys) {
+    var decodedJWT = null;
     try {
-      var decodedJWT = decodeJWT(idToken);
+      decodedJWT = decodeJWT(idToken);
       verifySignature(decodedJWT, keys.keys);
       verifyPayload(decodedJWT.payload, audience);
     } catch (e) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -69,8 +69,8 @@ function verifyPayload(payload, audience) {
 
 exports.verify = function (idToken, audience, callback) {
   certCache.global.getFederatedGoogleCerts(function (err, keys) {
-    var decodedJWT = null;
     var error = null;
+    var decodedJWT = null;
     try {
       decodedJWT = decodeJWT(idToken);
       verifySignature(decodedJWT, keys.keys);

--- a/lib/main.js
+++ b/lib/main.js
@@ -73,10 +73,9 @@ exports.verify = function (idToken, audience, callback) {
       var decodedJWT = decodeJWT(idToken);
       verifySignature(decodedJWT, keys.keys);
       verifyPayload(decodedJWT.payload, audience);
-
-      callback(null, decodedJWT.payload);
     } catch (e) {
       callback(e, null);
     }
+    callback(null, decodedJWT.payload);
   });
 };


### PR DESCRIPTION
Prevent swallowing of exceptions in the callback by moving callback out of try/catch
